### PR TITLE
Add initial root example

### DIFF
--- a/docs/example-templates/components/root.jsx
+++ b/docs/example-templates/components/root.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { HashRouter } from 'react-router-dom';
+import App from './app';
+
+const Root = ({ store }) => (
+  <Provider store={store}>
+    <HashRouter>
+      <App />
+    </HashRouter>
+  </Provider>
+);
+
+export default Root;


### PR DESCRIPTION
Add template for root.jsx file. Currently includes HashRouter but we can leave this out if we want.