### PR TITLE
Fix XMLHttp util file, update actions with examples for both

### DIFF
--- a/docs/example-templates/actions/example_actions.js
+++ b/docs/example-templates/actions/example_actions.js
@@ -3,7 +3,15 @@ import {
   getToApi,
   patchToApi,
   postToApi
-} from '../util/api_util';
+} from '../util/api_util_fetch';
+
+// **For browsers that do not support fetch**
+// import {
+//   deleteToApi,
+//   getToApi,
+//   patchToApi,
+//   postToApi
+// } from '../util/api_util_xmlhttp';
 
 export const RECEIVE_SINGLE_EXAMPLE = "RECEIVE_SINGLE_EXAMPLE";
 export const RECEIVE_EXAMPLES = "RECEIVE_EXAMPLES";

--- a/docs/example-templates/util/api_util_xmlhttp.js
+++ b/docs/example-templates/util/api_util_xmlhttp.js
@@ -8,16 +8,17 @@ const _toApi = function _toApi(url, method, payload, token) {
     const xhr = new XMLHttpRequest();
 
     xhr.onload = function xhrOnload() {
-      resolve(JSON.parse(this.responseBody));
+      resolve(JSON.parse(this.response));
     };
 
     xhr.onerror = function xhrOnerror() {
-      reject(JSON.parse(this.responseBody));
+      reject(JSON.parse(this.response));
     };
 
     const params = JSON.stringify(payload);
+    const fullUrl = apiUrl + url;
 
-    xhr.open(method, url);
+    xhr.open(method, fullUrl);
     xhr.setRequestHeader('Content-Type', 'application/json');
     xhr.setRequestHeader('Authorization', `Token ${token}`);
     xhr.send(params);

--- a/docs/example_app/sample/.gitignore
+++ b/docs/example_app/sample/.gitignore
@@ -12,7 +12,6 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-/node_modules/*
 /node_modules
 # Ignore Byebug command history file.
 .byebug_history

--- a/docs/example_app/sample/.gitignore
+++ b/docs/example_app/sample/.gitignore
@@ -12,7 +12,8 @@
 /tmp/*
 !/log/.keep
 !/tmp/.keep
-
+/node_modules/*
+/node_modules
 # Ignore Byebug command history file.
 .byebug_history
 

--- a/docs/example_app/sample/frontend/actions/example_actions.js
+++ b/docs/example_app/sample/frontend/actions/example_actions.js
@@ -5,6 +5,14 @@ import {
   postToApi
 } from '../util/api_util_fetch';
 
+// **For browsers that do not support fetch**
+// import {
+//   deleteToApi,
+//   getToApi,
+//   patchToApi,
+//   postToApi
+// } from '../util/api_util_xmlhttp';
+
 export const RECEIVE_SINGLE_EXAMPLE = "RECEIVE_SINGLE_EXAMPLE";
 export const RECEIVE_EXAMPLES = "RECEIVE_EXAMPLES";
 export const REMOVE_EXAMPLE = "REMOVE_EXAMPLE";

--- a/docs/example_app/sample/frontend/util/api_util_xmlhttp.js
+++ b/docs/example_app/sample/frontend/util/api_util_xmlhttp.js
@@ -1,23 +1,24 @@
 // The following is an easily configurable, modular
 // CRUD interface. It uses the fetch protocal.
 
-const apiUrl = '[API_URL_HERE]';
+const apiUrl = 'http://localhost:3000/api/';
 
 const _toApi = function _toApi(url, method, payload, token) {
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
 
     xhr.onload = function xhrOnload() {
-      resolve(JSON.parse(this.responseBody));
+      resolve(JSON.parse(this.response));
     };
 
     xhr.onerror = function xhrOnerror() {
-      reject(JSON.parse(this.responseBody));
+      reject(JSON.parse(this.response));
     };
 
     const params = JSON.stringify(payload);
+    const fullUrl = apiUrl + url;
 
-    xhr.open(method, url);
+    xhr.open(method, fullUrl);
     xhr.setRequestHeader('Content-Type', 'application/json');
     xhr.setRequestHeader('Authorization', `Token ${token}`);
     xhr.send(params);


### PR DESCRIPTION
XMLHttp now calls `response` instead of the [wrong] `responseBody`.
XMLHttp now uses apiUrl.
example-actions now has examples for both `fetch` and `XMLHttp`.
gitignore locally ignores node_modules folder.