### PR TITLE
Remove redux-thunk and create custom thunk

### DIFF
--- a/docs/example-templates/middleware/thunk.js
+++ b/docs/example-templates/middleware/thunk.js
@@ -1,0 +1,17 @@
+// Sourced from redux-thunk (https://github.com/gaearon/redux-thunk)
+// Duplicted here in order to minimize dependence on further packages
+
+function createThunkMiddleware(extraArgument) {
+  return ({ dispatch, getState }) => next => (action) => {
+    if (typeof action === 'function') {
+      return action(dispatch, getState, extraArgument);
+    }
+
+    return next(action);
+  };
+}
+
+const thunk = createThunkMiddleware();
+thunk.withExtraArgument = createThunkMiddleware;
+
+export default thunk;

--- a/docs/example_app/sample/frontend/middleware/thunk.js
+++ b/docs/example_app/sample/frontend/middleware/thunk.js
@@ -1,0 +1,17 @@
+// Sourced from redux-thunk (https://github.com/gaearon/redux-thunk)
+// Duplicted here in order to minimize dependence on further packages
+
+function createThunkMiddleware(extraArgument) {
+  return ({ dispatch, getState }) => next => (action) => {
+    if (typeof action === 'function') {
+      return action(dispatch, getState, extraArgument);
+    }
+
+    return next(action);
+  };
+}
+
+const thunk = createThunkMiddleware();
+thunk.withExtraArgument = createThunkMiddleware;
+
+export default thunk;

--- a/docs/example_app/sample/frontend/store/store.js
+++ b/docs/example_app/sample/frontend/store/store.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux';
-import thunk from 'redux-thunk';
+import thunk from '../middleware/thunk';
 import RootReducer from '../reducers/root_reducer';
 
 const configureStore = (preloadedState = {}) => (

--- a/docs/example_app/sample/package.json
+++ b/docs/example_app/sample/package.json
@@ -18,7 +18,6 @@
     "react-dom": "^15.5.4",
     "react-redux": "^5.0.5",
     "redux": "^3.6.0",
-    "redux-thunk": "^2.2.0",
     "webpack": "^2.6.1"
   },
   "devDependencies": {},


### PR DESCRIPTION
At the present time, redux-thunk will not be incorporated into the core functionality. The motivation for this decision is to minimize reliance on external packages. Thunk functionality has been replicated in an included local file.